### PR TITLE
Fix trimmed headers in helm-org-rifle-show-path mode

### DIFF
--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -1035,7 +1035,7 @@ because it uses variables in its outer scope."
                                                  it))
                                         (--> (or path (org-get-outline-path))
                                              (append it (list heading))
-                                             (org-format-outline-path it)
+                                             (org-format-outline-path it (window-width))
                                              (org-link-display-format it))))
                                 (tags (if tags
                                           (concat " " (helm-org-rifle-fontify-like-in-org-mode tags))


### PR DESCRIPTION
Default width for this function is 79 characters, so it many headings end up trimmed.
Not sure how it went unnoticed, because I believe it's the code path taken by default settings :)